### PR TITLE
Yay

### DIFF
--- a/install/additional-tools/docker.sh
+++ b/install/additional-tools/docker.sh
@@ -7,12 +7,12 @@ source "$SCRIPT_DIR/../common.sh"
 
 print_step "Installing Docker..."
 
-if check_command paru; then
+if check_command yay; then
   print_info "Installing docker package..."
-  paru -S --noconfirm --needed docker
+  yay -S --noconfirm --needed docker
   
   print_info "Installing docker-buildx..."
-  paru -S --noconfirm --needed docker-buildx
+  yay -S --noconfirm --needed docker-buildx
 
   print_info "Enabling and starting docker.socket..."
   sudo systemctl enable --now docker.socket
@@ -22,5 +22,5 @@ if check_command paru; then
   
   print_info "Docker installation complete. You may need to log out and back in for group changes to take effect."
 else
-  print_warning "paru not found. Skipping Docker installation (likely non-Arch platform)."
+  print_warning "yay not found. Skipping Docker installation (likely non-Arch platform)."
 fi

--- a/install/additional-tools/shpool.sh
+++ b/install/additional-tools/shpool.sh
@@ -7,8 +7,8 @@ source "$SCRIPT_DIR/../common.sh"
 
 print_step "Installing shpool..."
 
-if check_command paru; then
-  paru -S --noconfirm --needed shpool
+if check_command yay; then
+  yay -S --noconfirm --needed shpool
 
   print_info "Configuring systemd services for shpool..."
   systemctl --user enable shpool
@@ -17,5 +17,5 @@ if check_command paru; then
   # Enable linger for the current user so services run without an active session
   loginctl enable-linger
 else
-  print_warning "paru not found. Skipping shpool installation (likely non-Arch platform)."
+  print_warning "yay not found. Skipping shpool installation (likely non-Arch platform)."
 fi

--- a/install/dotfiles.sh
+++ b/install/dotfiles.sh
@@ -12,8 +12,8 @@ print_step "Linking dotfiles..."
 # Check for stow
 if ! check_command stow; then
   print_warning "stow not found. Attempting to install..."
-  if check_command paru; then
-    paru -S --needed --noconfirm stow
+  if check_command yay; then
+    yay -S --needed --noconfirm stow
   elif check_command brew; then
     brew install stow
   elif check_command apt-get; then

--- a/install/install-arch.sh
+++ b/install/install-arch.sh
@@ -22,19 +22,19 @@ check_arch_linux() {
 # Update system packages
 update_system() {
   print_step "Updating system packages..."
-  sudo pacman -Sy --noconfirm
+  sudo pacman -Syu --noconfirm
 }
 
-# Install paru AUR helper if not present
-install_paru() {
-  if ! check_command paru; then
-    print_step "Installing paru AUR helper..."
+# Install yay AUR helper if not present
+install_yay() {
+  if ! check_command yay; then
+    print_step "Installing yay AUR helper..."
     sudo pacman -S --needed --noconfirm git base-devel
 
     local tmp_dir=$(mktemp -d)
-    git clone https://aur.archlinux.org/paru.git "$tmp_dir/paru"
+    git clone https://aur.archlinux.org/yay.git "$tmp_dir/yay"
 
-    pushd "$tmp_dir/paru" >/dev/null
+    pushd "$tmp_dir/yay" >/dev/null
     makepkg -si --noconfirm
     popd >/dev/null
 
@@ -45,7 +45,7 @@ install_paru() {
 # Configure Zsh as default shell
 setup_shell() {
   print_step "Configuring Zsh..."
-  paru -S --needed --noconfirm zsh
+  yay -S --needed --noconfirm zsh
 
   local zsh_path=$(which zsh)
   local current_shell=$(getent passwd "$USER" | cut -d: -f7)
@@ -72,9 +72,9 @@ install_packages_from_file() {
     return
   fi
 
-  # Install all packages using paru
+  # Install all packages using yay
   print_info "Installing packages:$packages"
-  paru -S --needed --noconfirm $packages
+  yay -S --needed --noconfirm $packages
 }
 
 # Main installation flow
@@ -83,7 +83,7 @@ main() {
 
   check_arch_linux
   update_system
-  install_paru
+  install_yay
   setup_shell
   install_packages_from_file "$PACKAGES_DIR/base.packages"
 

--- a/install/install-arch.sh
+++ b/install/install-arch.sh
@@ -85,12 +85,13 @@ main() {
   update_system
   install_yay
   setup_shell
+
+  # Install packages
   install_packages_from_file "$PACKAGES_DIR/base.packages"
-
-  # Link dotfiles
-  bash "$SCRIPT_DIR/dotfiles.sh"
-
   install_packages_from_file "$PACKAGES_DIR/dev.packages"
+
+  # Install additional tools
+  bash "$SCRIPT_DIR/additional-tools/all.sh"
 
   echo "✅ Setup complete! Package lists: $PACKAGES_DIR"
 }


### PR DESCRIPTION
This pull request updates the Arch Linux installation scripts to use the `yay` AUR helper instead of `paru` for package management. The changes ensure consistency across all scripts and improve compatibility for users who use `yay` as their AUR helper. Additionally, the system update command is improved to include both package synchronization and upgrades, and the installation flow is slightly reorganized.

**Migration from paru to yay:**

* All references to the `paru` AUR helper are replaced with `yay` in installation scripts, including checks, installation commands, and user messages (`install/additional-tools/docker.sh`, `install/additional-tools/shpool.sh`, `install/dotfiles.sh`, `install/install-arch.sh`). [[1]](diffhunk://#diff-940d191fec02bc4ec18f244d1e82de1120bd850ddc7803cdbb319c98f892eedfL10-R15) [[2]](diffhunk://#diff-940d191fec02bc4ec18f244d1e82de1120bd850ddc7803cdbb319c98f892eedfL25-R25) [[3]](diffhunk://#diff-2147f614c287237b990212a2e81d40ea72b6aba03c7ec2426cf427ea951a4e9bL10-R11) [[4]](diffhunk://#diff-2147f614c287237b990212a2e81d40ea72b6aba03c7ec2426cf427ea951a4e9bL20-R20) [[5]](diffhunk://#diff-882e871c0b8f627adde08fd2833f1c771cdaccb19d4144968a8d3c53fe4bed5bL15-R16) [[6]](diffhunk://#diff-79ddf3d0efe40e1dd4b1f9e462ce41284be6213d6727947f50ed58f9dd0661ecL48-R48) [[7]](diffhunk://#diff-79ddf3d0efe40e1dd4b1f9e462ce41284be6213d6727947f50ed58f9dd0661ecL75-R77)

* The function to install the AUR helper is renamed from `install_paru` to `install_yay`, and it now clones and installs `yay` instead of `paru` (`install/install-arch.sh`).

**System update improvement:**

* The system update command is changed from `pacman -Sy` to `pacman -Syu` to ensure both synchronization and package upgrades (`install/install-arch.sh`).

**Installation flow reorganization:**

* The main installation flow is updated to install additional tools after the base and development packages, and to use the new `yay`-based functions (`install/install-arch.sh`).