### PR TITLE
Fix for zsh setup authentication error

### DIFF
--- a/install/install-arch.sh
+++ b/install/install-arch.sh
@@ -52,8 +52,8 @@ setup_shell() {
 
   if [ "$current_shell" != "$zsh_path" ]; then
     print_info "Changing default shell to zsh ($zsh_path)..."
-    # chsh usually requires password input from user
-    chsh -s "$zsh_path"
+    # Use sudo usermod to avoid authentication token errors common in some environments
+    sudo usermod -s "$zsh_path" "$USER"
   else
     print_info "Default shell is already zsh."
   fi


### PR DESCRIPTION
This pull request makes a small but important improvement to the shell setup process in `install/install-arch.sh`. Instead of using `chsh`, which can cause authentication token errors in some environments, the script now uses `sudo usermod` to change the default shell to zsh.

* Changed the default shell update command from `chsh` to `sudo usermod` in `setup_shell()` to avoid authentication token errors in some environments.