### PR TITLE
Bash config cleanup

### DIFF
--- a/install/install-arch.sh
+++ b/install/install-arch.sh
@@ -77,6 +77,27 @@ install_packages_from_file() {
   yay -S --needed --noconfirm $packages
 }
 
+# Cleanup default bash files
+cleanup_bash_files() {
+  print_step "Cleaning up default Bash files..."
+  local backup_dir="$HOME/.bash.bak"
+  local files=(".bash_history" ".bash_logout" ".bash_profile" ".bashrc")
+
+  mkdir -p "$backup_dir"
+
+  for file in "${files[@]}"; do
+    if [ -f "$HOME/$file" ]; then
+      mv -f --backup=numbered "$HOME/$file" "$backup_dir/" ||
+        print_warning "Could not move $file to backup location. Skipping."
+
+      # Verify move was successful (file exists in backup or source is gone)
+      if [ -f "$backup_dir/$file" ] || [ ! -f "$HOME/$file" ]; then
+        print_info "Moved $file to $backup_dir/"
+      fi
+    fi
+  done
+}
+
 # Main installation flow
 main() {
   echo "=== Arch Linux Terminal Setup ==="
@@ -95,6 +116,9 @@ main() {
 
   # Install dotfiles
   bash "$SCRIPT_DIR/dotfiles.sh"
+
+  # Cleaup default bash config
+  cleanup_bash_files
 
   echo "✅ Setup complete! Package lists: $PACKAGES_DIR"
 }


### PR DESCRIPTION
This pull request adds a cleanup step to the Arch Linux terminal setup script that moves default Bash configuration files to a backup directory after installing dotfiles. This helps prevent conflicts between the new dotfiles and any existing Bash configuration files.

**Bash configuration cleanup:**

* Added a `cleanup_bash_files` function to move default Bash files (such as `.bashrc`, `.bash_profile`, `.bash_logout`, and `.bash_history`) from the user's home directory to a backup directory (`~/.bash.bak`), with checks and user feedback.
* Integrated the `cleanup_bash_files` function into the main installation flow, so it runs after dotfiles are installed.