### PR TITLE
Single login

### DIFF
--- a/install/common.sh
+++ b/install/common.sh
@@ -129,3 +129,16 @@ read_packages_for_platform() {
   
   echo "$packages"
 }
+# Request sudo permissions and keep alive
+ask_for_sudo() {
+  print_info "Prompting for sudo password..."
+  if sudo -v; then
+    # Keep-alive: update existing sudo time stamp if set, otherwise do nothing.
+    # We do this in the background
+    while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done >/dev/null 2>&1 &
+    print_step "Sudo credentials updated."
+  else
+    print_error "Sudo password incorrect or sudo not available."
+    exit 1
+  fi
+}

--- a/install/install-arch.sh
+++ b/install/install-arch.sh
@@ -103,6 +103,7 @@ main() {
   echo "=== Arch Linux Terminal Setup ==="
 
   check_arch_linux
+  ask_for_sudo
   update_system
   install_yay
   setup_shell


### PR DESCRIPTION
This pull request improves the installation process on Arch Linux by ensuring that sudo permissions are requested and maintained throughout the script execution. This helps prevent permission issues during installation steps that require elevated privileges.

Installation process improvements:

* Added an `ask_for_sudo` function in `install/common.sh` to prompt for the sudo password at the start and keep the sudo session alive in the background, reducing repeated password prompts and avoiding permission errors.
* Updated `install/install-arch.sh` to call `ask_for_sudo` at the beginning of the main installation process, ensuring all subsequent commands have the necessary permissions.