### PR TITLE
Add mise installer and integrate it into mac setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository serves three main purposes:
 ### 1. Consistent Cross-Platform Setup
 Whether running on a local MacBook or a remote Arch Linux VM, the environment looks and behaves exactly the same. The installation scripts handle the nuances of package management:
 *   **Arch Linux**: Uses `yay` for system and AUR packages.
-*   **macOS**: Uses Homebrew.
+*   **macOS**: Uses Homebrew and installs it automatically if it is missing.
 
 ### 2. Dotfiles Management
 The `config` directory contains the configuration files for all supported applications (Neovim, Zsh, NVM, etc.). GNU Stow is used to create and manage symlinks, ensuring these files are placed correctly in the home directory while keeping the repository clean.

--- a/config/dot-config/zsh/init.zsh
+++ b/config/dot-config/zsh/init.zsh
@@ -4,7 +4,9 @@ source /usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 
 # Initialize Homebrew on MacOS
 if [[ "$(uname -s)" == "Darwin" ]]; then
-  eval "$(/opt/homebrew/bin/brew shellenv)"
+  if [[ -x /opt/homebrew/bin/brew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  fi
 fi
 
 # Temporarily set as this will work in all cases I think once I standardize
@@ -24,7 +26,7 @@ if [ -f '$HOME/.local/share/google-cloud-sdk/completion.zsh.inc' ]; then . '$HOM
 
 # Mise Setup
 if command -v mise &> /dev/null; then
-  eval "$(~/.local/bin/mise activate zsh)"
+  eval "$($(command -v mise) activate zsh)"
 fi
 
 # NVM (Node Version Manager)

--- a/install/additional-tools/mise.sh
+++ b/install/additional-tools/mise.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+# Source common functions
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../common.sh"
+
+print_step "Installing mise..."
+
+if check_command mise; then
+  print_info "mise is already installed: $(mise --version)"
+  exit 0
+fi
+
+install_via_official_script() {
+  print_info "Installing mise via the official installer..."
+  curl https://mise.run | sh
+}
+
+case "$(uname -s)" in
+  Darwin)
+    install_via_official_script
+    ;;
+  Linux)
+    if [ -f /etc/arch-release ]; then
+      install_via_official_script
+    else
+      print_warning "Non-Arch Linux detected. Falling back to the official mise installer."
+      install_via_official_script
+    fi
+    ;;
+  *)
+    print_error "Unsupported platform: $(uname -s)"
+    exit 1
+    ;;
+esac
+
+if check_command mise; then
+  print_info "mise installed successfully: $(mise --version)"
+elif [ -x "$HOME/.local/bin/mise" ]; then
+  print_info "mise installed successfully: $("$HOME/.local/bin/mise" --version)"
+else
+  print_error "mise installation completed, but the binary was not found on PATH or at ~/.local/bin/mise"
+  exit 1
+fi

--- a/install/install-mac.sh
+++ b/install/install-mac.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Mac Terminal Setup Script
-# Prerequisites: Xcode Developer Tools and Homebrew must be installed
+# Prerequisites: Xcode Developer Tools must be installed
 
 set -e # Exit on error
 
@@ -10,6 +10,38 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 PACKAGES_DIR="$(dirname "$SCRIPT_DIR")/packages"
+
+ensure_homebrew_shellenv() {
+  if [ -x "/opt/homebrew/bin/brew" ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [ -x "/usr/local/bin/brew" ]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+}
+
+install_homebrew() {
+  print_step "Homebrew not found. Installing Homebrew..."
+
+  NONINTERACTIVE=1 /bin/bash -c \
+    "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+  ensure_homebrew_shellenv
+
+  if ! check_command brew; then
+    print_error "Homebrew installation completed, but 'brew' is still unavailable in this shell."
+    exit 1
+  fi
+}
+
+ensure_homebrew() {
+  ensure_homebrew_shellenv
+
+  if check_command brew; then
+    return
+  fi
+
+  install_homebrew
+}
 
 # Update Homebrew
 update_homebrew() {
@@ -38,9 +70,11 @@ install_packages_mac() {
 main() {
   echo "=== Mac Terminal Setup ==="
 
+  ensure_homebrew
   update_homebrew
   install_packages_mac "base packages" "$PACKAGES_DIR/base.packages"
   install_packages_mac "development packages" "$PACKAGES_DIR/dev.packages"
+  bash "$SCRIPT_DIR/additional-tools/mise.sh"
 
   echo "✅ Setup complete! Package lists: $PACKAGES_DIR"
 }


### PR DESCRIPTION
## Summary
- bootstrap Homebrew automatically during macOS setup when it is missing
- add an `install/additional-tools/mise.sh` installer using the official `mise.run` script
- run the `mise` installer from the macOS install flow
- update zsh `mise` activation to use the resolved binary from `PATH`
- refresh the README macOS install description

## Testing
- `bash -n install/additional-tools/mise.sh install/install-mac.sh`

## Notes
- This PR includes the existing branch commit that updated the macOS installer to bootstrap Homebrew automatically if needed.