### PR TITLE
Add AI context keybind for file refs

### DIFF
--- a/config/dot-config/nvim/plugin/ai.lua
+++ b/config/dot-config/nvim/plugin/ai.lua
@@ -15,6 +15,34 @@ local function is_ours(buf)
   return false
 end
 
+local function current_file_path()
+  local path = vim.api.nvim_buf_get_name(0)
+  if path == "" then return nil end
+
+  path = vim.fs.normalize(path)
+
+  local root = vim.fs.root(0, { ".git" }) or vim.fn.getcwd()
+  root = vim.fs.normalize(root)
+
+  if path:sub(1, #root + 1) == root .. "/" then
+    return path:sub(#root + 2)
+  end
+
+  return vim.fn.fnamemodify(path, ":~")
+end
+
+local function current_file_context(start_line, end_line)
+  local path = current_file_path()
+  if not path then return nil end
+
+  if start_line and end_line then
+    if start_line > end_line then start_line, end_line = end_line, start_line end
+    return string.format("@%s:%d-%d", path, start_line, end_line)
+  end
+
+  return "@" .. path
+end
+
 local function toggle(name, cmd)
   local s = state[name] or {}
   state[name] = s
@@ -31,17 +59,40 @@ local function toggle(name, cmd)
   else
     s.buf = vim.api.nvim_create_buf(false, false)
     vim.api.nvim_set_current_buf(s.buf)
-    vim.fn.jobstart(cmd, { -- launch once
+    s.job = vim.fn.jobstart(cmd, { -- launch once
       term = true,
       on_exit = function()
         vim.schedule(function()
           if valid(s.buf) then vim.api.nvim_buf_delete(s.buf, { force = true }) end
           s.buf = nil
+          s.job = nil
         end)
       end,
     })
   end
 
+  vim.cmd("startinsert")
+end
+
+local function ensure_ai_terminal()
+  toggle(last.name, last.cmd)
+  return state[last.name]
+end
+
+local function send_context_to_ai(start_line, end_line)
+  local text = current_file_context(start_line, end_line)
+  if not text then
+    vim.notify("No file context to send", vim.log.levels.WARN)
+    return
+  end
+
+  local s = ensure_ai_terminal()
+  if not s or not s.job then
+    vim.notify("AI terminal is not available", vim.log.levels.ERROR)
+    return
+  end
+
+  vim.fn.chansend(s.job, text)
   vim.cmd("startinsert")
 end
 
@@ -57,6 +108,10 @@ end
 -- Direct-to-tool
 vim.keymap.set("n", "<leader>ai", function() toggle("codex", "codex") end, { desc = "Codex" })
 vim.keymap.set("n", "<leader>ac", function() toggle("claude", "claude") end, { desc = "Claude" })
+vim.keymap.set("n", "<leader>as", function() send_context_to_ai() end, { desc = "Send file context to AI" })
+vim.keymap.set("v", "<leader>as", function()
+  send_context_to_ai(vim.fn.line("'<"), vim.fn.line("'>"))
+end, { desc = "Send selection context to AI" })
 
 -- Quick toggle of the last-used AI terminal, from normal or terminal mode
 vim.keymap.set({ "n", "t" }, "<C-.>", smart_toggle, { desc = "Toggle AI terminal" })

--- a/nvim.log
+++ b/nvim.log
@@ -1,0 +1,1 @@
+WRN 2026-05-26T07:20:01.847 ?.2        server_start:197: Failed to start server: operation not permitted: /run/user/1000/nvim.2.0


### PR DESCRIPTION
## Summary
- track AI terminal job ids so text can be sent to the running TUI
- add `<leader>as` to insert the current file as `@path`
- support visual selections as `@path:start-end` without auto-submitting
- resolve file refs relative to the project root when possible

## Validation
- `luac -p config/dot-config/nvim/plugin/ai.lua`
- `git diff --check -- config/dot-config/nvim/plugin/ai.lua`